### PR TITLE
Update pointer to current tab when the selected tab changes

### DIFF
--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -10,6 +10,7 @@
 #include "Settings.h"
 #include "SettingsDialog.h"
 #include "WebView.h"
+#include <AK/TypeCasts.h>
 #include <QAction>
 #include <QDialog>
 #include <QPlainTextEdit>
@@ -190,6 +191,7 @@ BrowserWindow::BrowserWindow()
     QObject::connect(m_tabs_container, &QTabWidget::currentChanged, [this](int index) {
         setWindowTitle(QString("%1 - Ladybird").arg(m_tabs_container->tabText(index)));
         setWindowIcon(m_tabs_container->tabIcon(index));
+        m_current_tab = verify_cast<Tab>(m_tabs_container->widget(index));
     });
     QObject::connect(m_tabs_container, &QTabWidget::tabCloseRequested, this, &BrowserWindow::close_tab);
     QObject::connect(close_current_tab_action, &QAction::triggered, this, &BrowserWindow::close_current_tab);

--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -46,7 +46,6 @@ BrowserWindow::BrowserWindow()
     quit_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q));
     menu->addAction(quit_action);
 
-
     auto* view_menu = menuBar()->addMenu("&View");
 
     auto* open_next_tab_action = new QAction("Open &Next Tab");
@@ -293,4 +292,3 @@ void BrowserWindow::open_previous_tab()
         next_index = m_tabs_container->count() - 1;
     m_tabs_container->setCurrentIndex(next_index);
 }
-


### PR DESCRIPTION
This allows requests like dumping the DOM tree to be forwarded to the
correct tab. Otherwise, the event would be forwarded to the most
recently created tab.