### PR TITLE
CMake: Install resources and Lagom libraries alongside ladybird 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(ladybird
     DESCRIPTION "Ladybird Web Browser"
 )
 
+include(GNUInstallDirs)
+
 if (ANDROID)
     set(BUILD_SHARED_LIBS OFF)
 endif()
@@ -19,7 +21,7 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 # See slide 100 of the following ppt :^)
 # https://crascit.com/wp-content/uploads/2019/09/Deep-CMake-For-Library-Authors-Craig-Scott-CppCon-2019.pdf
 if (NOT APPLE)
-    set(CMAKE_INSTALL_RPATH $ORIGIN)
+    set(CMAKE_INSTALL_RPATH $ORIGIN;$ORIGIN/../${CMAKE_INSTALL_LIBDIR})
 endif()
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
@@ -91,8 +93,6 @@ add_custom_target(debug
 
 qt_finalize_executable(ladybird)
 
-install(TARGETS ladybird
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    BUNDLE DESTINATION bundle
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
+if(NOT CMAKE_SKIP_INSTALL_RULES)
+    include(cmake/InstallRules.cmake)
+endif()

--- a/WebView.cpp
+++ b/WebView.cpp
@@ -17,6 +17,7 @@
 #include <AK/ByteBuffer.h>
 #include <AK/Format.h>
 #include <AK/HashTable.h>
+#include <AK/LexicalPath.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>
@@ -54,6 +55,7 @@
 #include <LibWebSocket/ConnectionInfo.h>
 #include <LibWebSocket/Message.h>
 #include <LibWebSocket/WebSocket.h>
+#include <QApplication>
 #include <QCursor>
 #include <QIcon>
 #include <QLineEdit>
@@ -76,15 +78,7 @@ QString qstring_from_akstring(AK::String const& akstring)
     return QString::fromUtf8(akstring.characters(), akstring.length());
 }
 
-String s_serenity_resource_root = [] {
-    auto const* source_dir = getenv("SERENITY_SOURCE_DIR");
-    if (source_dir) {
-        return String::formatted("{}/Base", source_dir);
-    }
-    auto* home = getenv("XDG_CONFIG_HOME") ?: getenv("HOME");
-    VERIFY(home);
-    return String::formatted("{}/.lagom", home);
-}();
+String s_serenity_resource_root;
 
 class HeadlessBrowserPageClient final : public Web::PageClient {
 public:
@@ -845,18 +839,33 @@ static void platform_init()
 #ifdef AK_OS_ANDROID
     extern void android_platform_init();
     android_platform_init();
+#else
+    s_serenity_resource_root = [] {
+        auto const* source_dir = getenv("SERENITY_SOURCE_DIR");
+        if (source_dir) {
+            return String::formatted("{}/Base", source_dir);
+        }
+        auto* home = getenv("XDG_CONFIG_HOME") ?: getenv("HOME");
+        VERIFY(home);
+        auto home_lagom = String::formatted("{}/.lagom", home);
+        if (Core::File::is_directory(home_lagom))
+            return home_lagom;
+        auto app_dir = akstring_from_qstring(QApplication::applicationDirPath());
+        return LexicalPath(app_dir).parent().append("share"sv).string();
+    }();
 #endif
 }
 
 void initialize_web_engine()
 {
+    platform_init();
+
     Web::Platform::EventLoopPlugin::install(*new Ladybird::EventLoopPluginQt);
 
     Web::ImageDecoding::Decoder::initialize(HeadlessImageDecoderClient::create());
     Web::ResourceLoader::initialize(RequestManagerQt::create());
     Web::WebSockets::WebSocketClientManager::initialize(HeadlessWebSocketClientManager::create());
 
-    platform_init();
 
     Web::FrameLoader::set_default_favicon_path(String::formatted("{}/res/icons/16x16/app-browser.png", s_serenity_resource_root));
 

--- a/cmake/InstallRules.cmake
+++ b/cmake/InstallRules.cmake
@@ -1,0 +1,75 @@
+
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+set(package ladybird)
+
+install(TARGETS ladybird
+  EXPORT ladybirdTargets
+  RUNTIME
+    COMPONENT ladybird_Runtime
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+  BUNDLE
+    COMPONENT ladybird_Runtime
+    DESTINATION bundle
+  LIBRARY
+    COMPONENT ladybird_Runtime
+    NAMELINK_COMPONENT ladybird_Development
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+include("${Lagom_SOURCE_DIR}/get_linked_lagom_libraries.cmake")
+get_linked_lagom_libraries(ladybird ladybird_lagom_libraries)
+
+install(TARGETS ${ladybird_lagom_libraries}
+  EXPORT ladybirdTargets
+  COMPONENT ladybird_Runtime
+  LIBRARY
+    COMPONENT ladybird_Runtime
+    NAMELINK_COMPONENT ladybird_Development
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+write_basic_package_version_file(
+    "${package}ConfigVersion.cmake"
+    COMPATIBILITY SameMajorVersion
+)
+
+# Allow package maintainers to freely override the path for the configs
+set(
+    ladybird_INSTALL_CMAKEDIR "${CMAKE_INSTALL_DATADIR}/${package}"
+    CACHE PATH "CMake package config location relative to the install prefix"
+)
+mark_as_advanced(ladybird_INSTALL_CMAKEDIR)
+
+install(
+    FILES cmake/LadybirdInstallConfig.cmake
+    DESTINATION "${ladybird_INSTALL_CMAKEDIR}"
+    RENAME "${package}Config.cmake"
+    COMPONENT ladybird_Development
+)
+
+install(
+    FILES "${PROJECT_BINARY_DIR}/${package}ConfigVersion.cmake"
+    DESTINATION "${ladybird_INSTALL_CMAKEDIR}"
+    COMPONENT ladybird_Development
+)
+
+install(
+    EXPORT ladybirdTargets
+    NAMESPACE ladybird::
+    DESTINATION "${ladybird_INSTALL_CMAKEDIR}"
+    COMPONENT ladybird_Development
+)
+
+install(DIRECTORY
+    "${SERENITY_SOURCE_DIR}/Base/res/html"
+    "${SERENITY_SOURCE_DIR}/Base/res/fonts"
+    "${SERENITY_SOURCE_DIR}/Base/res/icons"
+    "${SERENITY_SOURCE_DIR}/Base/res/themes"
+    "${SERENITY_SOURCE_DIR}/Base/res/color-palettes"
+    "${SERENITY_SOURCE_DIR}/Base/res/cursor-themes"
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/res"
+  USE_SOURCE_PERMISSIONS MESSAGE_NEVER
+  COMPONENT ladybird_Runtime
+)

--- a/cmake/LadybirdInstallConfig.cmake
+++ b/cmake/LadybirdInstallConfig.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/ladybirdTargets.cmake")


### PR DESCRIPTION
This setup should allow the package maintainers who are looking to
distribute ladybird on their distributions to use CMake to install
ladybird using cmake install rules rather than having to write their own

Requires https://github.com/SerenityOS/serenity/pull/15257

Fixes #36
