### PR TITLE
CMake: Link against LibSoftGPU to enable WebGL using serenity LibGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ set(SOURCES
 qt_add_executable(ladybird ${SOURCES}
     MANUAL_FINALIZATION
 )
-target_link_libraries(ladybird PRIVATE Qt::Widgets Qt::Network LibWeb LibWebSocket LibGL LibMain)
+target_link_libraries(ladybird PRIVATE Qt::Widgets Qt::Network LibWeb LibWebSocket LibGL LibSoftGPU LibMain)
 
 set_target_properties(ladybird PROPERTIES
     MACOSX_BUNDLE_GUI_IDENTIFIER org.serenityos.ladybird


### PR DESCRIPTION
In the future, ladybird should probably use a QOpenGLWidget or similar platform plugin to use the native GL implementation instead of the one in serenity.

Requires: https://github.com/SerenityOS/serenity/pull/15260

Fixes #16