### PR TITLE
WebView: Ensure there is a console widget when storing console messages and initialize console earlier

### DIFF
--- a/PageClientLadybird.cpp
+++ b/PageClientLadybird.cpp
@@ -118,7 +118,7 @@ void PageClientLadybird::page_did_start_loading(AK::URL const& url)
     emit m_view.load_started(url);
 }
 
-void PageClientLadybird::page_did_finish_loading(AK::URL const&)
+void PageClientLadybird::page_did_create_main_document()
 {
     initialize_js_console();
     m_console_client->send_messages(0);

--- a/PageClientLadybird.h
+++ b/PageClientLadybird.h
@@ -40,7 +40,7 @@ public:
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override;
     virtual void page_did_change_title(String const& title) override;
     virtual void page_did_start_loading(AK::URL const& url) override;
-    virtual void page_did_finish_loading(AK::URL const&) override;
+    virtual void page_did_create_main_document() override;
     void initialize_js_console();
     virtual void page_did_change_selection() override;
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) override;

--- a/WebView.cpp
+++ b/WebView.cpp
@@ -556,14 +556,13 @@ void WebView::did_output_js_console_message(i32 message_index)
 
 void WebView::did_get_js_console_messages(i32, Vector<String>, Vector<String> messages)
 {
-    if (!m_js_console_input_edit)
-        return;
+    ensure_js_console_widget();
     for (auto& message : messages) {
         m_js_console_output_edit->append(qstring_from_akstring(message).trimmed());
     }
 }
 
-void WebView::show_js_console()
+void WebView::ensure_js_console_widget()
 {
     if (!m_js_console_widget) {
         m_js_console_widget = new QWidget;
@@ -587,6 +586,11 @@ void WebView::show_js_console()
             m_page_client->m_console_client->handle_input(akstring_from_qstring(code));
         });
     }
+}
+
+void WebView::show_js_console()
+{
+    ensure_js_console_widget();
     m_js_console_widget->show();
     m_js_console_input_edit->setFocus();
 }

--- a/WebView.h
+++ b/WebView.h
@@ -71,6 +71,7 @@ signals:
 
 private:
     void update_viewport_rect();
+    void ensure_js_console_widget();
 
     OwnPtr<Ladybird::PageClientLadybird> m_page_client;
 


### PR DESCRIPTION
This requires the SerenityOS PR: https://github.com/SerenityOS/serenity/issues/15308