### PR TITLE
Implement translations

### DIFF
--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -30,55 +30,55 @@ BrowserWindow::BrowserWindow()
     m_tabs_bar = m_tabs_container->findChild<QTabBar*>();
     m_tabs_bar->hide();
 
-    auto* menu = menuBar()->addMenu("&File");
+    auto* menu = menuBar()->addMenu(tr("&File"));
 
-    auto* new_tab_action = new QAction("New &Tab");
+    auto* new_tab_action = new QAction(tr("New &Tab"));
     new_tab_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_T));
     menu->addAction(new_tab_action);
 
-    auto* settings_action = new QAction("&Settings");
+    auto* settings_action = new QAction(tr("&Settings"));
     settings_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Comma));
     menu->addAction(settings_action);
 
-    auto* close_current_tab_action = new QAction("Close Current Tab");
+    auto* close_current_tab_action = new QAction(tr("Close Current Tab"));
     close_current_tab_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_W));
     menu->addAction(close_current_tab_action);
 
-    auto* quit_action = new QAction("&Quit");
+    auto* quit_action = new QAction(tr("&Quit"));
     quit_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q));
     menu->addAction(quit_action);
 
-    auto* view_menu = menuBar()->addMenu("&View");
+    auto* view_menu = menuBar()->addMenu(tr("&View"));
 
-    auto* open_next_tab_action = new QAction("Open &Next Tab");
+    auto* open_next_tab_action = new QAction(tr("Open &Next Tab"));
     open_next_tab_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_PageDown));
     view_menu->addAction(open_next_tab_action);
     QObject::connect(open_next_tab_action, &QAction::triggered, this, &BrowserWindow::open_next_tab);
 
-    auto* open_previous_tab_action = new QAction("Open &Previous Tab");
+    auto* open_previous_tab_action = new QAction(tr("Open &Previous Tab"));
     open_previous_tab_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_PageUp));
     view_menu->addAction(open_previous_tab_action);
     QObject::connect(open_previous_tab_action, &QAction::triggered, this, &BrowserWindow::open_previous_tab);
 
     view_menu->addSeparator();
 
-    auto* color_scheme_menu = view_menu->addMenu("&Color Scheme");
+    auto* color_scheme_menu = view_menu->addMenu(tr("&Color Scheme"));
 
     auto* group = new QActionGroup(this);
 
-    auto* auto_color_scheme = new QAction("&Auto");
+    auto* auto_color_scheme = new QAction(tr("&Auto"));
     auto_color_scheme->setCheckable(true);
     group->addAction(auto_color_scheme);
     color_scheme_menu->addAction(auto_color_scheme);
     QObject::connect(auto_color_scheme, &QAction::triggered, this, &BrowserWindow::enable_auto_color_scheme);
 
-    auto* light_color_scheme = new QAction("&Light");
+    auto* light_color_scheme = new QAction(tr("&Light"));
     light_color_scheme->setCheckable(true);
     group->addAction(light_color_scheme);
     color_scheme_menu->addAction(light_color_scheme);
     QObject::connect(light_color_scheme, &QAction::triggered, this, &BrowserWindow::enable_light_color_scheme);
 
-    auto* dark_color_scheme = new QAction("&Dark");
+    auto* dark_color_scheme = new QAction(tr("&Dark"));
     dark_color_scheme->setCheckable(true);
     group->addAction(dark_color_scheme);
     color_scheme_menu->addAction(dark_color_scheme);
@@ -86,9 +86,9 @@ BrowserWindow::BrowserWindow()
 
     auto_color_scheme->setChecked(true);
 
-    auto* inspect_menu = menuBar()->addMenu("&Inspect");
+    auto* inspect_menu = menuBar()->addMenu(tr("&Inspect"));
 
-    auto* view_source_action = new QAction("View &Source");
+    auto* view_source_action = new QAction(tr("View &Source"));
     view_source_action->setIcon(QIcon(QString("%1/res/icons/16x16/filetype-html.png").arg(s_serenity_resource_root.characters())));
     view_source_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_U));
     inspect_menu->addAction(view_source_action);
@@ -104,7 +104,7 @@ BrowserWindow::BrowserWindow()
         }
     });
 
-    auto* js_console_action = new QAction("Show &JS Console");
+    auto* js_console_action = new QAction(tr("Show &JS Console"));
     js_console_action->setIcon(QIcon(QString("%1/res/icons/16x16/filetype-javascript.png").arg(s_serenity_resource_root.characters())));
     js_console_action->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_J));
     inspect_menu->addAction(js_console_action);
@@ -114,51 +114,51 @@ BrowserWindow::BrowserWindow()
         }
     });
 
-    auto* debug_menu = menuBar()->addMenu("&Debug");
+    auto* debug_menu = menuBar()->addMenu(tr("&Debug"));
 
-    auto* dump_dom_tree_action = new QAction("Dump DOM Tree");
+    auto* dump_dom_tree_action = new QAction(tr("Dump DOM Tree"));
     dump_dom_tree_action->setIcon(QIcon(QString("%1/res/icons/browser/dom-tree.png").arg(s_serenity_resource_root.characters())));
     debug_menu->addAction(dump_dom_tree_action);
     QObject::connect(dump_dom_tree_action, &QAction::triggered, this, [this] {
         debug_request("dump-dom-tree");
     });
 
-    auto* dump_layout_tree_action = new QAction("Dump Layout Tree");
+    auto* dump_layout_tree_action = new QAction(tr("Dump Layout Tree"));
     dump_layout_tree_action->setIcon(QIcon(QString("%1/res/icons/16x16/layout.png").arg(s_serenity_resource_root.characters())));
     debug_menu->addAction(dump_layout_tree_action);
     QObject::connect(dump_layout_tree_action, &QAction::triggered, this, [this] {
         debug_request("dump-layout-tree");
     });
 
-    auto* dump_stacking_context_tree_action = new QAction("Dump Stacking Context Tree");
+    auto* dump_stacking_context_tree_action = new QAction(tr("Dump Stacking Context Tree"));
     dump_stacking_context_tree_action->setIcon(QIcon(QString("%1/res/icons/16x16/layers.png").arg(s_serenity_resource_root.characters())));
     debug_menu->addAction(dump_stacking_context_tree_action);
     QObject::connect(dump_stacking_context_tree_action, &QAction::triggered, this, [this] {
         debug_request("dump-stacking-context-tree");
     });
 
-    auto* dump_style_sheets_action = new QAction("Dump Style Sheets");
+    auto* dump_style_sheets_action = new QAction(tr("Dump Style Sheets"));
     dump_style_sheets_action->setIcon(QIcon(QString("%1/res/icons/16x16/filetype-css.png").arg(s_serenity_resource_root.characters())));
     debug_menu->addAction(dump_style_sheets_action);
     QObject::connect(dump_style_sheets_action, &QAction::triggered, this, [this] {
         debug_request("dump-style-sheets");
     });
 
-    auto* dump_history_action = new QAction("Dump History");
+    auto* dump_history_action = new QAction(tr("Dump History"));
     dump_history_action->setIcon(QIcon(QString("%1/res/icons/16x16/history.png").arg(s_serenity_resource_root.characters())));
     debug_menu->addAction(dump_history_action);
     QObject::connect(dump_history_action, &QAction::triggered, this, [this] {
         debug_request("dump-history");
     });
 
-    auto* dump_cookies_action = new QAction("Dump Cookies");
+    auto* dump_cookies_action = new QAction(tr("Dump Cookies"));
     dump_cookies_action->setIcon(QIcon(QString("%1/res/icons/browser/cookie.png").arg(s_serenity_resource_root.characters())));
     debug_menu->addAction(dump_cookies_action);
     QObject::connect(dump_cookies_action, &QAction::triggered, this, [this] {
         debug_request("dump-cookies");
     });
 
-    auto* dump_local_storage_action = new QAction("Dump Local Storage");
+    auto* dump_local_storage_action = new QAction(tr("Dump Local Storage"));
     dump_local_storage_action->setIcon(QIcon(QString("%1/res/icons/browser/local-storage.png").arg(s_serenity_resource_root.characters())));
     debug_menu->addAction(dump_local_storage_action);
     QObject::connect(dump_local_storage_action, &QAction::triggered, this, [this] {
@@ -167,7 +167,7 @@ BrowserWindow::BrowserWindow()
 
     debug_menu->addSeparator();
 
-    auto* show_line_box_borders_action = new QAction("Show Line Box Borders");
+    auto* show_line_box_borders_action = new QAction(tr("Show Line Box Borders"));
     show_line_box_borders_action->setCheckable(true);
     debug_menu->addAction(show_line_box_borders_action);
     QObject::connect(show_line_box_borders_action, &QAction::triggered, this, [this, show_line_box_borders_action] {
@@ -177,14 +177,14 @@ BrowserWindow::BrowserWindow()
 
     debug_menu->addSeparator();
 
-    auto* collect_garbage_action = new QAction("Collect Garbage");
+    auto* collect_garbage_action = new QAction(tr("Collect Garbage"));
     collect_garbage_action->setIcon(QIcon(QString("%1/res/icons/16x16/trash-can.png").arg(s_serenity_resource_root.characters())));
     debug_menu->addAction(collect_garbage_action);
     QObject::connect(collect_garbage_action, &QAction::triggered, this, [this] {
         debug_request("collect-garbage");
     });
 
-    auto* clear_cache_action = new QAction("Clear Cache");
+    auto* clear_cache_action = new QAction(tr("Clear Cache"));
     clear_cache_action->setIcon(QIcon(QString("%1/res/icons/browser/clear-cache.png").arg(s_serenity_resource_root.characters())));
     debug_menu->addAction(clear_cache_action);
     QObject::connect(clear_cache_action, &QAction::triggered, this, [this] {
@@ -193,7 +193,7 @@ BrowserWindow::BrowserWindow()
 
     debug_menu->addSeparator();
 
-    auto* enable_scripting_action = new QAction("Enable Scripting");
+    auto* enable_scripting_action = new QAction(tr("Enable Scripting"));
     enable_scripting_action->setCheckable(true);
     enable_scripting_action->setChecked(true);
     debug_menu->addAction(enable_scripting_action);
@@ -202,7 +202,7 @@ BrowserWindow::BrowserWindow()
         debug_request("scripting", state ? "on" : "off");
     });
 
-    auto* enable_same_origin_policy_action = new QAction("Enable Same-Origin Policy");
+    auto* enable_same_origin_policy_action = new QAction(tr("Enable Same-Origin Policy"));
     enable_same_origin_policy_action->setCheckable(true);
     debug_menu->addAction(enable_same_origin_policy_action);
     QObject::connect(enable_same_origin_policy_action, &QAction::triggered, this, [this, enable_same_origin_policy_action] {
@@ -245,7 +245,7 @@ void BrowserWindow::new_tab()
         m_current_tab = tab_ptr;
     }
 
-    m_tabs_container->addTab(tab_ptr, "New Tab");
+    m_tabs_container->addTab(tab_ptr, tr("New Tab"));
     m_tabs_container->setCurrentWidget(tab_ptr);
 
     QObject::connect(tab_ptr, &Tab::title_changed, this, &BrowserWindow::tab_title_changed);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ add_compile_options(-Wno-user-defined-literals)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets Network)
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets Network LinguistTools)
 
 set(SOURCES
     BrowserWindow.cpp
@@ -71,6 +71,15 @@ set(SOURCES
 qt_add_executable(ladybird ${SOURCES}
     MANUAL_FINALIZATION
 )
+qt_add_translations(ladybird
+    TS_FILES i18n/ladybird_de.ts i18n/ladybird_en.ts
+    SOURCES ${SOURCES}
+)
+
+qt_add_resources(ladybird "i18n"
+    PREFIX "/i18n"
+    FILES ${QM_FILES})
+
 target_link_libraries(ladybird PRIVATE Qt::Widgets Qt::Network LibWeb LibWebSocket LibGL LibSoftGPU LibMain)
 
 set_target_properties(ladybird PROPERTIES

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ export SERENITY_SOURCE_DIR=${PWD}/Build/serenity
 ./Build/ladybird # or, in macOS: open ./Build/ladybird.app
 ```
 
+## Updating translation files
+
+If you change, add or remove any strings, it is recommended to update the translation files before commiting:
+
+```
+ninja -C Build ladybird_lupdate
+```
+
 ## Experimental Android Build Steps
 
 ### Prepping Qt Creator

--- a/SettingsDialog.cpp
+++ b/SettingsDialog.cpp
@@ -16,9 +16,9 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
 {
     m_layout = new QFormLayout;
     m_homepage = new QLineEdit;
-    m_ok_button = new QPushButton("&Save");
+    m_ok_button = new QPushButton(tr("&Save"));
 
-    m_layout->addWidget(new QLabel("Homepage"));
+    m_layout->addWidget(new QLabel(tr("Homepage")));
     m_layout->addWidget(m_homepage);
     m_layout->addWidget(m_ok_button);
 
@@ -28,7 +28,7 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
         close();
     });
     
-    setWindowTitle("Settings");
+    setWindowTitle(tr("Settings"));
     setFixedWidth(300);
     setLayout(m_layout);
     show();

--- a/i18n/ladybird_de.ts
+++ b/i18n/ladybird_de.ts
@@ -71,7 +71,7 @@
     <message>
         <location filename="../BrowserWindow.cpp" line="91"/>
         <source>View &amp;Source</source>
-        <translation>Seitenquelltet anzeigen</translation>
+        <translation>Seitenquelltext anzeigen</translation>
     </message>
     <message>
         <location filename="../BrowserWindow.cpp" line="107"/>

--- a/i18n/ladybird_de.ts
+++ b/i18n/ladybird_de.ts
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
+<context>
+    <name>BrowserWindow</name>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="33"/>
+        <source>&amp;File</source>
+        <translation>Datei</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="35"/>
+        <source>New &amp;Tab</source>
+        <translation>Neuer &amp;Tab</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="39"/>
+        <source>&amp;Settings</source>
+        <translation>Ein&amp;stellungen</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="43"/>
+        <source>Close Current Tab</source>
+        <translation>Aktuellen Tab schließen</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="47"/>
+        <source>&amp;Quit</source>
+        <translation>Beenden</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="51"/>
+        <source>&amp;View</source>
+        <translation>Ansicht</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="53"/>
+        <source>Open &amp;Next Tab</source>
+        <translation>&amp;Nächsten Tab öffnen</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="58"/>
+        <source>Open &amp;Previous Tab</source>
+        <translation>Vorherigen Tab öffnen</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="65"/>
+        <source>&amp;Color Scheme</source>
+        <translation>Farbschema</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="69"/>
+        <source>&amp;Auto</source>
+        <translation>&amp;Auto</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="75"/>
+        <source>&amp;Light</source>
+        <translation>He&amp;ll</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="81"/>
+        <source>&amp;Dark</source>
+        <translation>&amp;Dunkel</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="89"/>
+        <source>&amp;Inspect</source>
+        <translation>Untersuchen</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="91"/>
+        <source>View &amp;Source</source>
+        <translation>Seitenquelltet anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="107"/>
+        <source>Show &amp;JS Console</source>
+        <translation>&amp;JS-Konsole öffnen</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="117"/>
+        <source>&amp;Debug</source>
+        <translation>&amp;Debugging</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="119"/>
+        <source>Dump DOM Tree</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="126"/>
+        <source>Dump Layout Tree</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="133"/>
+        <source>Dump Stacking Context Tree</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="140"/>
+        <source>Dump Style Sheets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="147"/>
+        <source>Dump History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="154"/>
+        <source>Dump Cookies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="161"/>
+        <source>Dump Local Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="170"/>
+        <source>Show Line Box Borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="180"/>
+        <source>Collect Garbage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="187"/>
+        <source>Clear Cache</source>
+        <translation>Cache leeren</translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="196"/>
+        <source>Enable Scripting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="205"/>
+        <source>Enable Same-Origin Policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="248"/>
+        <source>New Tab</source>
+        <translation>Neuer Tab</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../SettingsDialog.cpp" line="19"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Speichern</translation>
+    </message>
+    <message>
+        <location filename="../SettingsDialog.cpp" line="21"/>
+        <source>Homepage</source>
+        <translation>Startseite</translation>
+    </message>
+    <message>
+        <location filename="../SettingsDialog.cpp" line="31"/>
+        <source>Settings</source>
+        <translation>Einstellungen</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../main.cpp" line="34"/>
+        <source>The Ladybird web browser :^)</source>
+        <translation>Der Ladybird-Webbrowser :^)</translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="35"/>
+        <source>URL to open</source>
+        <translation>Zu öffnende URL</translation>
+    </message>
+</context>
+</TS>

--- a/i18n/ladybird_en.ts
+++ b/i18n/ladybird_en.ts
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US">
+<context>
+    <name>BrowserWindow</name>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="33"/>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="35"/>
+        <source>New &amp;Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="39"/>
+        <source>&amp;Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="43"/>
+        <source>Close Current Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="47"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="51"/>
+        <source>&amp;View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="53"/>
+        <source>Open &amp;Next Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="58"/>
+        <source>Open &amp;Previous Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="65"/>
+        <source>&amp;Color Scheme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="69"/>
+        <source>&amp;Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="75"/>
+        <source>&amp;Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="81"/>
+        <source>&amp;Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="89"/>
+        <source>&amp;Inspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="91"/>
+        <source>View &amp;Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="107"/>
+        <source>Show &amp;JS Console</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="117"/>
+        <source>&amp;Debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="119"/>
+        <source>Dump DOM Tree</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="126"/>
+        <source>Dump Layout Tree</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="133"/>
+        <source>Dump Stacking Context Tree</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="140"/>
+        <source>Dump Style Sheets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="147"/>
+        <source>Dump History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="154"/>
+        <source>Dump Cookies</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="161"/>
+        <source>Dump Local Storage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="170"/>
+        <source>Show Line Box Borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="180"/>
+        <source>Collect Garbage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="187"/>
+        <source>Clear Cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="196"/>
+        <source>Enable Scripting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="205"/>
+        <source>Enable Same-Origin Policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../BrowserWindow.cpp" line="248"/>
+        <source>New Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../SettingsDialog.cpp" line="19"/>
+        <source>&amp;Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SettingsDialog.cpp" line="21"/>
+        <source>Homepage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SettingsDialog.cpp" line="31"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <location filename="../main.cpp" line="34"/>
+        <source>The Ladybird web browser :^)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.cpp" line="35"/>
+        <source>URL to open</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/main.cpp
+++ b/main.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/Timer.h>
 #include <LibMain/Main.h>
 #include <QApplication>
+#include <QTranslator>
 #include <QWidget>
 
 extern void initialize_web_engine();
@@ -19,13 +20,19 @@ Browser::Settings* s_settings;
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     QApplication app(arguments.argc, arguments.argv);
+    auto locale = QLocale::system();
+
+    QTranslator translator;
+
+    if (translator.load(locale, "ladybird", "_", ":/i18n"))
+        app.installTranslator(&translator);
 
     initialize_web_engine();
 
     String url;
     Core::ArgsParser args_parser;
-    args_parser.set_general_help("The Ladybird web browser :^)");
-    args_parser.add_positional_argument(url, "URL to open", "url", Core::ArgsParser::Required::No);
+    args_parser.set_general_help(qPrintable(QCoreApplication::translate("main", "The Ladybird web browser :^)")));
+    args_parser.add_positional_argument(url, qPrintable(QCoreApplication::translate("main", "URL to open")), "url", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
     s_settings = new Browser::Settings();


### PR DESCRIPTION
This adds translations to Ladybird. I initially translated it into German, but other languages can easily be added. I'm not actually sure if an English translation file is needed, but it could be helpful if you want to use translation tools like weblate.

Ideally, `ninja -C Build ladybird_lupdate` should be run after every change (maybe as a pre-commit hook?) because the .ts files in QT reference line numbers of the source files. But the lines numbers are only used to help translation and not required for any functionality.

Translations are currently embedded into the binary, but could also be moved into separate files (Embedding seemed easier to me).