### PR TITLE
Make Tab.cpp directly take a BrowserWindows as m_window

### DIFF
--- a/Tab.cpp
+++ b/Tab.cpp
@@ -18,7 +18,7 @@
 extern String s_serenity_resource_root;
 extern Browser::Settings* s_settings;
 
-Tab::Tab(QMainWindow* window)
+Tab::Tab(BrowserWindow* window)
     : m_window(window)
 {
     m_layout = new QBoxLayout(QBoxLayout::Direction::TopToBottom, this);
@@ -146,10 +146,7 @@ void Tab::page_favicon_changed(QIcon icon)
 
 int Tab::tab_index()
 {
-    // FIXME: I hear you like footguns...
-    //        There has to be a better way of doing this
-    auto browser_window = reinterpret_cast<BrowserWindow*>(m_window);
-    return browser_window->tab_index(this);
+    return m_window->tab_index(this);
 }
 
 void Tab::debug_request(String const& request, String const& argument)

--- a/Tab.h
+++ b/Tab.h
@@ -17,10 +17,12 @@
 #include <QToolBar>
 #include <QWidget>
 
+class BrowserWindow;
+
 class Tab final : public QWidget {
     Q_OBJECT
 public:
-    explicit Tab(QMainWindow* window);
+    explicit Tab(BrowserWindow* window);
 
     WebView& view() { return *m_view; }
 
@@ -51,7 +53,7 @@ private:
     QToolBar* m_toolbar { nullptr };
     QLineEdit* m_location_edit { nullptr };
     WebView* m_view { nullptr };
-    QMainWindow* m_window { nullptr };
+    BrowserWindow* m_window { nullptr };
     Browser::History m_history;
     QString m_title;
     QLabel* m_hover_label { nullptr };


### PR DESCRIPTION
This should be safer than using `QMainWindow` and `reinterpret_cast`. I assume there was a reason for using QMainWindow though, if there was, please let me know and close this PR.