### PR TITLE
BrowserWindow: Make "View Source" a separate window

### DIFF
--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -97,6 +97,7 @@ BrowserWindow::BrowserWindow()
             auto source = m_current_tab->view().source();
 
             auto* text_edit = new QPlainTextEdit(this);
+            text_edit->setWindowFlags(Qt::Window);
             text_edit->setFont(QFontDatabase::systemFont(QFontDatabase::SystemFont::FixedFont));
             text_edit->resize(800, 600);
             text_edit->setPlainText(source.characters());


### PR DESCRIPTION
View Source was a subwindow that made it cover part of the browser with no way for closing it.
Was:
![view_source_1](https://user-images.githubusercontent.com/19346060/193655932-c997e33d-5125-4a64-b24d-12d42a829800.png)
Now:
![view_source_2](https://user-images.githubusercontent.com/19346060/193655978-9177c63f-0ce3-467a-b7e3-1e5dae222825.png)

Note that this doesn't change the fact that the View Source window is still a child of the Browser Window.