### PR TITLE
Make ladybird depend on WebContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,3 +101,4 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
 endif()
 
 add_subdirectory(WebContent)
+add_dependencies(ladybird WebContent)


### PR DESCRIPTION
This causes CMake to output a WebContent build, without this it would not build WebContent and Ladybird would be unusable since it couldn't find the WebContent executable.