### PR TITLE
Ensure that installed ladybird can launch WebContent process properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,9 @@ add_custom_target(debug
 
 qt_finalize_executable(ladybird)
 
+add_subdirectory(WebContent)
+add_dependencies(ladybird WebContent)
+
 if(NOT CMAKE_SKIP_INSTALL_RULES)
     include(cmake/InstallRules.cmake)
 endif()
-
-add_subdirectory(WebContent)
-add_dependencies(ladybird WebContent)

--- a/WebContent/CMakeLists.txt
+++ b/WebContent/CMakeLists.txt
@@ -1,10 +1,10 @@
 set(WEBCONTENT_SOURCE_DIR ${SERENITY_SOURCE_DIR}/Userland/Services/WebContent/)
 
 set(WEBCONTENT_SOURCES
-    ${WEBCONTENT_SOURCE_DIR}/ConnectionFromClient.cpp    
-    ${WEBCONTENT_SOURCE_DIR}/ConsoleGlobalObject.cpp    
-    ${WEBCONTENT_SOURCE_DIR}/PageHost.cpp    
-    ${WEBCONTENT_SOURCE_DIR}/WebContentConsoleClient.cpp    
+    ${WEBCONTENT_SOURCE_DIR}/ConnectionFromClient.cpp
+    ${WEBCONTENT_SOURCE_DIR}/ConsoleGlobalObject.cpp
+    ${WEBCONTENT_SOURCE_DIR}/PageHost.cpp
+    ${WEBCONTENT_SOURCE_DIR}/WebContentConsoleClient.cpp
     ../EventLoopPluginQt.cpp
     ../FontPluginQt.cpp
     ../ImageCodecPluginLadybird.cpp
@@ -14,7 +14,7 @@ set(WEBCONTENT_SOURCES
     ../WebSocketClientManagerLadybird.cpp
     ../WebSocketLadybird.cpp
     main.cpp
-)    
+)
 
 qt_add_executable(WebContent ${WEBCONTENT_SOURCES})
 

--- a/WebContent/main.cpp
+++ b/WebContent/main.cpp
@@ -38,9 +38,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // FIXME: Refactor things so we can get rid of this somehow.
     Core::EventLoop event_loop;
 
-    platform_init();
-
     QGuiApplication app(arguments.argc, arguments.argv);
+
+    platform_init();
 
     Web::Platform::EventLoopPlugin::install(*new Ladybird::EventLoopPluginQt);
     Web::Platform::ImageCodecPlugin::install(*new Ladybird::ImageCodecPluginLadybird);

--- a/WebContentView.cpp
+++ b/WebContentView.cpp
@@ -571,6 +571,8 @@ void WebContentView::create_client()
 
         auto rc = execlp("./WebContent/WebContent", "WebContent", nullptr);
         if (rc < 0)
+            rc = execlp((QCoreApplication::applicationDirPath() + "/WebContent").toStdString().c_str(), "WebContent", nullptr);
+        if (rc < 0)
             perror("execlp");
         VERIFY_NOT_REACHED();
     }

--- a/cmake/InstallRules.cmake
+++ b/cmake/InstallRules.cmake
@@ -18,10 +18,23 @@ install(TARGETS ladybird
     DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
+install(TARGETS WebContent
+  EXPORT ladybirdTargets
+  RUNTIME
+    COMPONENT ladybird_Runtime
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+  BUNDLE
+    COMPONENT ladybird_Runtime
+    DESTINATION bundle
+)
+
 include("${Lagom_SOURCE_DIR}/get_linked_lagom_libraries.cmake")
 get_linked_lagom_libraries(ladybird ladybird_lagom_libraries)
+get_linked_lagom_libraries(WebContent webcontent_lagom_libraries)
+list(APPEND all_required_lagom_libraries ${ladybird_lagom_libraries} ${webcontent_lagom_libraries})
+list(REMOVE_DUPLICATES all_required_lagom_libraries)
 
-install(TARGETS ${ladybird_lagom_libraries}
+install(TARGETS ${all_required_lagom_libraries}
   EXPORT ladybirdTargets
   COMPONENT ladybird_Runtime
   LIBRARY

--- a/main.cpp
+++ b/main.cpp
@@ -17,17 +17,17 @@ Browser::Settings* s_settings;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    platform_init();
-
-    // NOTE: We only instantiate this to ensure that Gfx::FontDatabase has its default queries initialized.
-    Gfx::FontDatabase::set_default_font_query("Katica 10 400 0");
-    Gfx::FontDatabase::set_fixed_width_font_query("Csilla 10 400 0");
-
     // NOTE: This is only used for the Core::Socket inside the IPC connections.
     // FIXME: Refactor things so we can get rid of this somehow.
     Core::EventLoop event_loop;
 
     QApplication app(arguments.argc, arguments.argv);
+
+    platform_init();
+
+    // NOTE: We only instantiate this to ensure that Gfx::FontDatabase has its default queries initialized.
+    Gfx::FontDatabase::set_default_font_query("Katica 10 400 0");
+    Gfx::FontDatabase::set_fixed_width_font_query("Csilla 10 400 0");
 
     String url;
     Core::ArgsParser args_parser;


### PR DESCRIPTION
Always call platform_init after there's a QApplication, because in the installed configuration that's how we find the resources.

Try QCoreApplication::applicationDirPath() after looking in ./WebContent for the WebContent process. In an installed configuration, ladybird and WebContent will both be in $PREFIX/bin.

Add install rules for WebContent and its linked libraries, for if they ever differ from ladybird's.