### PR TITLE
CMake: Some debugging improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ add_custom_target(run
 )
 
 add_custom_target(debug
-    COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SERENITY_SOURCE_DIR}" gdb "$<TARGET_FILE:ladybird>"
+    COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SERENITY_SOURCE_DIR}" gdb -ex "set follow-fork-mode child" "$<TARGET_FILE:ladybird>"
     USES_TERMINAL
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,21 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(cmake/EnableLLD.cmake)
 
+if (ENABLE_ADDRESS_SANITIZER)
+    add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=address)
+endif()
+
+if (ENABLE_MEMORY_SANITIZER)
+    add_compile_options(-fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=memory -fsanitize-memory-track-origins)
+endif()
+
+if (ENABLE_UNDEFINED_SANITIZER)
+    add_compile_options(-fsanitize=undefined -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=undefined)
+endif()
+
 # Lagom
 include(FetchContent)
 include(cmake/FetchLagom.cmake)


### PR DESCRIPTION
This pull request adds flags for ASAN, MSAN and UBSAN as well as configures gdb to follow forks, making debugging WebContent with `ninja debug` a bit nicer