### PR TITLE
Ignore SIGINT when we're being debugged

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -10,17 +10,47 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
+#include <LibCore/Stream.h>
+#include <LibCore/System.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibMain/Main.h>
 #include <QApplication>
 
 Browser::Settings* s_settings;
 
+static ErrorOr<void> handle_attached_debugger()
+{
+#ifdef AK_OS_LINUX
+    // Let's ignore SIGINT if we're being debugged because GDB
+    // incorrectly forwards the signal to us even when it's set to
+    // "nopass". See https://sourceware.org/bugzilla/show_bug.cgi?id=9425
+    // for details.
+    auto unbuffered_status_file = TRY(Core::Stream::File::open("/proc/self/status"sv, Core::Stream::OpenMode::Read));
+    auto status_file = TRY(Core::Stream::BufferedFile::create(move(unbuffered_status_file)));
+    auto buffer = TRY(ByteBuffer::create_uninitialized(4096));
+    while (TRY(status_file->can_read_line())) {
+        auto line = TRY(status_file->read_line(buffer));
+        auto const parts = line.split_view(':');
+        if (parts.size() < 2 || parts[0] != "TracerPid"sv)
+            continue;
+        auto tracer_pid = parts[1].to_uint<u32>();
+        if (tracer_pid != 0UL) {
+            dbgln("Debugger is attached, ignoring SIGINT");
+            TRY(Core::System::signal(SIGINT, SIG_IGN));
+        }
+        break;
+    }
+#endif
+    return {};
+}
+
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     // NOTE: This is only used for the Core::Socket inside the IPC connections.
     // FIXME: Refactor things so we can get rid of this somehow.
     Core::EventLoop event_loop;
+
+    TRY(handle_attached_debugger());
 
     QApplication app(arguments.argc, arguments.argv);
 


### PR DESCRIPTION
Let's ignore SIGINT if we're being debugged because GDB incorrectly forwards the signal to us even when it's set to "nopass". See https://sourceware.org/bugzilla/show_bug.cgi?id=9425 for details.