### PR TITLE
Documentation: Added Void Linux Dependencies

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -19,6 +19,11 @@ On Fedora or derivatives:
 sudo dnf install cmake libglvnd-devel ninja-build qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland-devel
 ```
 
+On Void Linux:
+```
+sudo xbps-install base-devel cmake glu-devel ninja qt6-base-devel qt6-tools-devel
+```
+
 On macOS:
 
 ```


### PR DESCRIPTION
Added dependencies for Void Linux.
Note: Neither GCC 11+ or Clang 13+ are not available through xbps. Not sure if that should be put in there.