### PR TITLE
Don't update the window title when a background tab changes its title

### DIFF
--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -334,10 +334,12 @@ void BrowserWindow::tab_title_changed(int index, QString const& title)
 {
     if (title.isEmpty()) {
         m_tabs_container->setTabText(index, "...");
-        setWindowTitle("Ladybird");
+        if (m_tabs_container->currentIndex() == index)
+            setWindowTitle("Ladybird");
     } else {
         m_tabs_container->setTabText(index, title);
-        setWindowTitle(QString("%1 - Ladybird").arg(title));
+        if (m_tabs_container->currentIndex() == index)
+            setWindowTitle(QString("%1 - Ladybird").arg(title));
     }
 }
 

--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -346,7 +346,8 @@ void BrowserWindow::tab_title_changed(int index, QString const& title)
 void BrowserWindow::tab_favicon_changed(int index, QIcon icon)
 {
     m_tabs_container->setTabIcon(index, icon);
-    setWindowIcon(icon);
+    if (m_tabs_container->currentIndex() == index)
+        setWindowIcon(icon);
 }
 
 void BrowserWindow::open_next_tab()


### PR DESCRIPTION
Steps to reproduce:
1. Open the Cookie Clicker game in a tab.
2. Open another website in another tab and make that the current tab.
3. Observe how the window's title mentions Cookie Clicker.