### PR TITLE
Select location editor text on focus

### DIFF
--- a/BrowserWindow.h
+++ b/BrowserWindow.h
@@ -42,6 +42,7 @@ public slots:
 
 private:
     void debug_request(String const& request, String const& argument = "");
+    bool eventFilter(QObject* obj, QEvent* event);
 
     QTabWidget* m_tabs_container { nullptr };
     NonnullOwnPtrVector<Tab> m_tabs;

--- a/Tab.cpp
+++ b/Tab.cpp
@@ -147,6 +147,7 @@ void Tab::reload()
 void Tab::location_edit_return_pressed()
 {
     navigate(m_location_edit->text());
+    m_location_edit->clearFocus();
 }
 
 void Tab::page_title_changed(QString title)

--- a/Tab.h
+++ b/Tab.h
@@ -30,6 +30,8 @@ public:
 
     void debug_request(String const& request, String const& argument);
 
+    QLineEdit* m_location_edit { nullptr };
+
 public slots:
     void focus_location_editor();
     void location_edit_return_pressed();
@@ -51,7 +53,6 @@ private:
 
     QBoxLayout* m_layout;
     QToolBar* m_toolbar { nullptr };
-    QLineEdit* m_location_edit { nullptr };
     WebContentView* m_view { nullptr };
     BrowserWindow* m_window { nullptr };
     Browser::History m_history;


### PR DESCRIPTION
This PR lets us match the behavior of other browsers when clicking to
focus the location editor.