### PR TITLE
Handle forward and backward mouse buttons

### DIFF
--- a/Tab.cpp
+++ b/Tab.cpp
@@ -73,6 +73,14 @@ Tab::Tab(BrowserWindow* window)
         m_hover_label->hide();
     });
 
+    QObject::connect(m_view, &WebContentView::back_mouse_button, [this] {
+        back();
+    });
+
+    QObject::connect(m_view, &WebContentView::forward_mouse_button, [this] {
+        forward();
+    });
+
     QObject::connect(m_view, &WebContentView::load_started, [this](const URL& url) {
         m_location_edit->setText(url.to_string().characters());
         m_history.push(url, m_title.toUtf8().data());

--- a/WebContentView.cpp
+++ b/WebContentView.cpp
@@ -308,6 +308,14 @@ void WebContentView::mouseReleaseEvent(QMouseEvent* event)
 {
     Gfx::IntPoint position(event->position().x() / m_inverse_pixel_scaling_ratio, event->position().y() / m_inverse_pixel_scaling_ratio);
     auto button = get_button_from_qt_event(*event);
+
+    if (event->button() & Qt::MouseButton::BackButton) {
+        emit back_mouse_button();
+    }
+    else if (event->button() & Qt::MouseButton::ForwardButton) {
+        emit forward_mouse_button();
+    }
+
     if (button == 0) {
         // We could not convert Qt buttons to something that Lagom can
         // recognize - don't even bother propagating this to the web engine

--- a/WebContentView.h
+++ b/WebContentView.h
@@ -143,6 +143,8 @@ public:
 signals:
     void link_hovered(QString, int timeout = 0);
     void link_unhovered();
+    void back_mouse_button();
+    void forward_mouse_button();
     void load_started(const URL&);
     void title_changed(QString);
     void favicon_changed(QIcon);


### PR DESCRIPTION
We now emit a new signal for backward mouse button's mouseup and forward mouse button's mouseup which is handled by going back and forward in the history respectively:))