### PR TITLE
Fix reloading functionality

### DIFF
--- a/Tab.cpp
+++ b/Tab.cpp
@@ -157,7 +157,8 @@ void Tab::home()
 
 void Tab::reload()
 {
-    view().reload();
+    m_is_history_navigation = true;
+    view().load(m_history.current().url.to_string());
 }
 
 void Tab::location_edit_return_pressed()

--- a/WebContentView.cpp
+++ b/WebContentView.cpp
@@ -79,11 +79,6 @@ WebContentView::~WebContentView()
 {
 }
 
-void WebContentView::reload()
-{
-    load(m_url);
-}
-
 void WebContentView::load(AK::URL const& url)
 {
     m_url = url;

--- a/WebContentView.h
+++ b/WebContentView.h
@@ -53,7 +53,6 @@ public:
 
     void load(AK::URL const&);
     void load_html(StringView html, AK::URL const&);
-    void reload();
 
     Function<void(Gfx::IntPoint const& screen_position)> on_context_menu_request;
     Function<void(const AK::URL&, String const& target, unsigned modifiers)> on_link_click;


### PR DESCRIPTION
Previoulsy, reloading went back to the first page loaded by WebView::load() or WebView::load_html(), as they are the only methods that modify m_url, which is what the reload loaded. Now we handle reloads in Tab.cpp by simply loading the last entry in the m_history.