### PR TITLE
Don't add initial about:blank load to history

### DIFF
--- a/Tab.cpp
+++ b/Tab.cpp
@@ -114,6 +114,8 @@ Tab::Tab(BrowserWindow* window)
 
     // FIXME: This is a hack to make the JS console usable in new windows.
     //        Something else should ensure that there's an initial about:blank document loaded in the view.
+    //        We set m_is_history_navigation = true so that the initial about:blank doesn't get added to the history.
+    m_is_history_navigation = true;
     m_view->load("about:blank"sv);
 }
 


### PR DESCRIPTION
The hackish initial loading of about:blank was previously added to the history, so you could go back to it (which wasn't very ergonomic). Now we set the m_is_history_navigation flag before loading it so it doesn't get added to the history.