### PR TITLE
Stub out new cookie WebView::ViewImplementation APIs

### DIFF
--- a/WebContentView.cpp
+++ b/WebContentView.cpp
@@ -885,6 +885,16 @@ void WebContentView::notify_server_did_change_favicon(Gfx::Bitmap const& bitmap)
     emit favicon_changed(QIcon(qpixmap));
 }
 
+Vector<Web::Cookie::Cookie> WebContentView::notify_server_did_request_all_cookies(Badge<WebContentClient>, AK::URL const&)
+{
+    return {};
+}
+
+Optional<Web::Cookie::Cookie> WebContentView::notify_server_did_request_named_cookie(Badge<WebContentClient>, AK::URL const&, String const&)
+{
+    return {};
+}
+
 String WebContentView::notify_server_did_request_cookie(Badge<WebContentClient>, AK::URL const& url, Web::Cookie::Source source)
 {
     if (on_get_cookie)
@@ -896,6 +906,10 @@ void WebContentView::notify_server_did_set_cookie(Badge<WebContentClient>, AK::U
 {
     if (on_set_cookie)
         on_set_cookie(url, cookie, source);
+}
+
+void WebContentView::notify_server_did_update_cookie(Badge<WebContentClient>, AK::URL const&, Web::Cookie::Cookie const&)
+{
 }
 
 void WebContentView::notify_server_did_update_resource_count(i32 count_waiting)

--- a/WebContentView.h
+++ b/WebContentView.h
@@ -134,8 +134,11 @@ public:
     virtual void notify_server_did_output_js_console_message(i32 message_index) override;
     virtual void notify_server_did_get_js_console_messages(i32 start_index, Vector<String> const& message_types, Vector<String> const& messages) override;
     virtual void notify_server_did_change_favicon(Gfx::Bitmap const& favicon) override;
+    virtual Vector<Web::Cookie::Cookie> notify_server_did_request_all_cookies(Badge<WebContentClient>, AK::URL const& url) override;
+    virtual Optional<Web::Cookie::Cookie> notify_server_did_request_named_cookie(Badge<WebContentClient>, AK::URL const& url, String const& name) override;
     virtual String notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::Source source) override;
     virtual void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source) override;
+    virtual void notify_server_did_update_cookie(Badge<WebContentClient>, AK::URL const& url, Web::Cookie::Cookie const& cookie) override;
     virtual void notify_server_did_update_resource_count(i32 count_waiting) override;
     virtual void notify_server_did_request_restore_window() override;
     virtual Gfx::IntPoint notify_server_did_request_reposition_window(Gfx::IntPoint const&) override;


### PR DESCRIPTION
These were added for WebDriver, which doesn't have a Ladybird implementation yet.

Depends on https://github.com/SerenityOS/serenity/pull/16031 being merged first.