### PR TITLE
Update WebContentView's stored URL when a page starts/finishes loading

### DIFF
--- a/WebContentView.cpp
+++ b/WebContentView.cpp
@@ -804,13 +804,13 @@ void WebContentView::notify_server_did_middle_click_link(Badge<WebContentClient>
 
 void WebContentView::notify_server_did_start_loading(Badge<WebContentClient>, AK::URL const& url)
 {
+    m_url = url;
     emit load_started(url);
 }
 
 void WebContentView::notify_server_did_finish_loading(Badge<WebContentClient>, AK::URL const& url)
 {
-    // FIXME
-    (void)url;
+    m_url = url;
 }
 
 void WebContentView::notify_server_did_request_navigate_back(Badge<WebContentClient>)


### PR DESCRIPTION
Similar to https://github.com/SerenityOS/serenity/commit/9782660. Unlike Serenity's browser, this doesn't affect reloading the page, as Ladybird refers to the History object for reloading (which is updated already on page load). However, this URL is used for e.g. crash reporting, so let's update it here as well.