### PR TITLE
Add stub callback for notify_server_did_finish_handling_input_event

### DIFF
--- a/WebContentView.cpp
+++ b/WebContentView.cpp
@@ -1055,3 +1055,10 @@ bool WebContentView::event(QEvent* event)
     }
     return QAbstractScrollArea::event(event);
 }
+
+void WebContentView::notify_server_did_finish_handling_input_event(bool event_was_accepted)
+{
+    // FIXME: Currently Ladybird handles the keyboard shortcuts before passing the event to web content, so
+    //        we don't need to do anything here. But we'll need to once we start asking web content first.
+    (void)event_was_accepted;
+}

--- a/WebContentView.h
+++ b/WebContentView.h
@@ -156,6 +156,7 @@ public:
     virtual Gfx::IntRect notify_server_did_request_minimize_window() override;
     virtual Gfx::IntRect notify_server_did_request_fullscreen_window() override;
     virtual void notify_server_did_request_file(Badge<WebContentClient>, String const& path, i32) override;
+    virtual void notify_server_did_finish_handling_input_event(bool event_was_accepted) override;
 
 signals:
     void link_hovered(QString, int timeout = 0);


### PR DESCRIPTION
This doesn't need to do anything yet, but will do once we start passing events to web content *before* they're passed to our GUI.

This implements the changes from https://github.com/SerenityOS/serenity/pull/16128 - please merge them together. :^)