### PR TITLE
Replace history entry if loading URL because of a redirect

### DIFF
--- a/Tab.cpp
+++ b/Tab.cpp
@@ -81,7 +81,13 @@ Tab::Tab(BrowserWindow* window, int webdriver_fd_passing_socket)
         forward();
     });
 
-    QObject::connect(m_view, &WebContentView::load_started, [this](const URL& url) {
+    QObject::connect(m_view, &WebContentView::load_started, [this](const URL& url, bool is_redirect) {
+        // If we are loading due to a redirect, we replace the current history entry
+        // with the loaded URL
+        if (is_redirect) {
+            m_history.replace_current(url, m_title.toUtf8().data());
+        }
+
         m_location_edit->setText(url.to_string().characters());
 
         // Don't add to history if back or forward is pressed

--- a/WebContentView.cpp
+++ b/WebContentView.cpp
@@ -802,10 +802,10 @@ void WebContentView::notify_server_did_middle_click_link(Badge<WebContentClient>
     (void)modifiers;
 }
 
-void WebContentView::notify_server_did_start_loading(Badge<WebContentClient>, AK::URL const& url)
+void WebContentView::notify_server_did_start_loading(Badge<WebContentClient>, AK::URL const& url, bool is_redirect)
 {
     m_url = url;
-    emit load_started(url);
+    emit load_started(url, is_redirect);
 }
 
 void WebContentView::notify_server_did_finish_loading(Badge<WebContentClient>, AK::URL const& url)

--- a/WebContentView.h
+++ b/WebContentView.h
@@ -123,7 +123,7 @@ public:
     virtual void notify_server_did_unhover_link(Badge<WebContentClient>) override;
     virtual void notify_server_did_click_link(Badge<WebContentClient>, const AK::URL&, String const& target, unsigned modifiers) override;
     virtual void notify_server_did_middle_click_link(Badge<WebContentClient>, const AK::URL&, String const& target, unsigned modifiers) override;
-    virtual void notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL&) override;
+    virtual void notify_server_did_start_loading(Badge<WebContentClient>, const AK::URL&, bool) override;
     virtual void notify_server_did_finish_loading(Badge<WebContentClient>, const AK::URL&) override;
     virtual void notify_server_did_request_navigate_back(Badge<WebContentClient>) override;
     virtual void notify_server_did_request_navigate_forward(Badge<WebContentClient>) override;
@@ -162,7 +162,7 @@ signals:
     void link_unhovered();
     void back_mouse_button();
     void forward_mouse_button();
-    void load_started(const URL&);
+    void load_started(const URL&, bool);
     void title_changed(QString);
     void favicon_changed(QIcon);
     void got_source(URL, QString);


### PR DESCRIPTION
We now replace the current history entry if the page-load has been caused because of a redirect. This makes it able to traverse the history if one of the entries redirects you, which previously caused an infinite history traversion loop.

Depends on https://github.com/SerenityOS/serenity/pull/16004