### PR TITLE
Laydibird/UI: select location when you change tab

### DIFF
--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -274,6 +274,7 @@ BrowserWindow::BrowserWindow(int webdriver_fd_passing_socket)
         setWindowTitle(QString("%1 - Ladybird").arg(m_tabs_container->tabText(index)));
         setWindowIcon(m_tabs_container->tabIcon(index));
         m_current_tab = verify_cast<Tab>(m_tabs_container->widget(index));
+        m_current_tab->select_location();
     });
     QObject::connect(m_tabs_container, &QTabWidget::tabCloseRequested, this, &BrowserWindow::close_tab);
     QObject::connect(close_current_tab_action, &QAction::triggered, this, &BrowserWindow::close_current_tab);
@@ -356,8 +357,11 @@ void BrowserWindow::tab_title_changed(int index, QString const& title)
 {
     if (title.isEmpty()) {
         m_tabs_container->setTabText(index, "...");
-        if (m_tabs_container->currentIndex() == index)
+        if (m_tabs_container->currentIndex() == index) {
             setWindowTitle("Ladybird");
+            if (m_current_tab->current_location() == "about:blank")
+                m_current_tab->select_location();
+        }
     } else {
         m_tabs_container->setTabText(index, title);
         if (m_tabs_container->currentIndex() == index)

--- a/Tab.h
+++ b/Tab.h
@@ -29,6 +29,7 @@ public:
     void navigate(QString);
 
     void debug_request(String const& request, String const& argument);
+    const QString current_location()const { return m_location_edit->text(); }
 
 public slots:
     void focus_location_editor();
@@ -39,6 +40,7 @@ public slots:
     void forward();
     void home();
     void reload();
+    void select_location(){ m_location_edit->selectAll(); }
 
 signals:
     void title_changed(int id, QString);


### PR DESCRIPTION
When you move to another tab, other browsers automatically select the location editor - so you can navigate into a new page. Lets do this.

Another hack I added here - when we just open a new tab - also select the location edit (this was tricky since we load a new page on new tabs)

This PR, is somewhat based on https://github.com/SerenityOS/ladybird/pull/112