### PR TITLE
Fix to build with JS::MarkupGenerator converted to use new string type

### DIFF
--- a/ConsoleWidget.cpp
+++ b/ConsoleWidget.cpp
@@ -132,7 +132,7 @@ void ConsoleWidget::print_source_line(StringView source)
     html.append("&gt; "sv);
     html.append("</span>"sv);
 
-    html.append(JS::MarkupGenerator::html_from_source(source));
+    html.append(JS::MarkupGenerator::html_from_source(source).release_value_but_fixme_should_propagate_errors());
 
     print_html(html.string_view());
 }


### PR DESCRIPTION
Fix to build after JS::MarkupGenerator got converted to use new string type:
https://github.com/SerenityOS/serenity/commit/112b3f73429eff7a3b6947c7fb45c62a0e5c0727