### PR TITLE
Quit SQLServer when its connected client exits

### DIFF
--- a/SQLServer/main.cpp
+++ b/SQLServer/main.cpp
@@ -36,6 +36,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto client = TRY(SQLServer::ConnectionFromClient::try_create(move(socket), 1));
     client->set_fd_passing_socket(TRY(Core::Stream::LocalSocket::adopt_fd(sql_server_fd_passing_socket)));
     client->set_database_path(move(database_path));
+    client->on_disconnect = [&]() {
+        loop.quit(0);
+    };
 
     return loop.exec();
 }


### PR DESCRIPTION
When Ladybird exits, SQLServer can get stuck spinning at 100% CPU after the socket connection is closed. This changes the client to quit the event loop when that disconnect happens to ensure that SQLServer is properly destroyed.

Depends on https://github.com/SerenityOS/serenity/pull/16401