### PR TITLE
Reimplement the DOM inspector :^) 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SOURCES
     ${BROWSER_SOURCE_DIR}/History.cpp
     BrowserWindow.cpp
     ConsoleWidget.cpp
+    InspectorWidget.cpp
     ModelTranslator.cpp
     Settings.cpp
     SettingsDialog.cpp

--- a/ConsoleGlobalObject.h
+++ b/ConsoleGlobalObject.h
@@ -39,7 +39,6 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const& name) override;
     virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
 
-
 private:
     virtual void visit_edges(Visitor&) override;
 

--- a/ConsoleWidget.h
+++ b/ConsoleWidget.h
@@ -35,7 +35,6 @@ public:
     Function<void(i32)> on_request_messages;
 
 private:
-
     void request_console_messages();
     void clear_output();
 

--- a/DOMNodeProperties.h
+++ b/DOMNodeProperties.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+
+namespace Ladybird {
+
+struct DOMNodeProperties {
+    String computed_style_json;
+    String resolved_style_json;
+    String custom_properties_json;
+};
+
+}

--- a/InspectorWidget.cpp
+++ b/InspectorWidget.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#define AK_DONT_REPLACE_STD
+
+#include "InspectorWidget.h"
+#include <LibWebView/DOMTreeModel.h>
+#include <QCloseEvent>
+#include <QTreeView>
+#include <QVBoxLayout>
+
+namespace Ladybird {
+
+InspectorWidget::InspectorWidget()
+{
+    setLayout(new QVBoxLayout);
+    m_tree_view = new QTreeView;
+    m_tree_view->setHeaderHidden(true);
+    m_tree_view->expandToDepth(3);
+    layout()->addWidget(m_tree_view);
+    m_tree_view->setModel(&m_dom_model);
+    QObject::connect(m_tree_view->selectionModel(), &QItemSelectionModel::selectionChanged,
+        [this](QItemSelection const& selected, QItemSelection const&) {
+            auto indexes = selected.indexes();
+            if (indexes.size()) {
+                auto index = m_dom_model.to_gui(indexes.first());
+                set_selection(index);
+            }
+        });
+}
+
+void InspectorWidget::clear_dom_json()
+{
+    m_dom_model.set_underlying_model(nullptr);
+}
+
+void InspectorWidget::set_dom_json(StringView dom_json)
+{
+    m_dom_model.set_underlying_model(::WebView::DOMTreeModel::create(dom_json));
+}
+
+void InspectorWidget::closeEvent(QCloseEvent* event)
+{
+    event->accept();
+    if (on_close)
+        on_close();
+}
+
+void InspectorWidget::set_selection(GUI::ModelIndex index)
+{
+    if (!index.is_valid())
+        return;
+
+    auto* json = static_cast<JsonObject const*>(index.internal_data());
+    VERIFY(json);
+
+    Selection selection {};
+    if (json->has_u32("pseudo-element"sv)) {
+        selection.dom_node_id = json->get("parent-id"sv).to_i32();
+        selection.pseudo_element = static_cast<Web::CSS::Selector::PseudoElement>(json->get("pseudo-element"sv).to_u32());
+    } else {
+        selection.dom_node_id = json->get("id"sv).to_i32();
+    }
+
+    if (selection == m_selection)
+        return;
+    m_selection = selection;
+
+    VERIFY(on_dom_node_inspected);
+    on_dom_node_inspected(m_selection.dom_node_id, m_selection.pseudo_element);
+}
+
+}

--- a/InspectorWidget.h
+++ b/InspectorWidget.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "DOMNodeProperties.h"
 #include "ModelTranslator.h"
 #include <AK/Optional.h>
 #include <AK/StringView.h>
@@ -13,6 +14,7 @@
 #include <QWidget>
 
 class QTreeView;
+class QTableView;
 
 namespace Ladybird {
 
@@ -31,16 +33,22 @@ public:
     void clear_dom_json();
     void set_dom_json(StringView dom_json);
 
-    Function<void(i32, Optional<Web::CSS::Selector::PseudoElement>)> on_dom_node_inspected;
+    void load_style_json(StringView computed_style_json, StringView resolved_style_json, StringView custom_properties_json);
+    void clear_style_json();
+
+    Function<ErrorOr<DOMNodeProperties>(i32, Optional<Web::CSS::Selector::PseudoElement>)> on_dom_node_inspected;
     Function<void()> on_close;
 
 private:
     void set_selection(GUI::ModelIndex);
     void closeEvent(QCloseEvent*) override;
 
-    QTreeView* m_tree_view { nullptr };
-    ModelTranslator m_dom_model {};
     Selection m_selection;
+
+    ModelTranslator m_dom_model {};
+    ModelTranslator m_computed_style_model {};
+    ModelTranslator m_resolved_style_model {};
+    ModelTranslator m_custom_properties_model {};
 };
 
 }

--- a/InspectorWidget.h
+++ b/InspectorWidget.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "ModelTranslator.h"
+#include <AK/Optional.h>
+#include <AK/StringView.h>
+#include <LibWeb/CSS/Selector.h>
+#include <QWidget>
+
+class QTreeView;
+
+namespace Ladybird {
+
+class InspectorWidget final : public QWidget {
+    Q_OBJECT
+public:
+    InspectorWidget();
+    virtual ~InspectorWidget() = default;
+
+    struct Selection {
+        i32 dom_node_id { 0 };
+        Optional<Web::CSS::Selector::PseudoElement> pseudo_element {};
+        bool operator==(Selection const& other) const = default;
+    };
+
+    void clear_dom_json();
+    void set_dom_json(StringView dom_json);
+
+    Function<void(i32, Optional<Web::CSS::Selector::PseudoElement>)> on_dom_node_inspected;
+    Function<void()> on_close;
+
+private:
+    void set_selection(GUI::ModelIndex);
+    void closeEvent(QCloseEvent*) override;
+
+    QTreeView* m_tree_view { nullptr };
+    ModelTranslator m_dom_model {};
+    Selection m_selection;
+};
+
+}

--- a/ModelTranslator.cpp
+++ b/ModelTranslator.cpp
@@ -12,20 +12,19 @@
 
 namespace Ladybird {
 
-ModelTranslator::ModelTranslator(NonnullRefPtr<GUI::Model> model)
-    : m_model(move(model))
-{
-}
-
 ModelTranslator::~ModelTranslator() = default;
 
 int ModelTranslator::columnCount(QModelIndex const& parent) const
 {
+    if (!m_model)
+        return 0;
     return m_model->column_count(to_gui(parent));
 }
 
 int ModelTranslator::rowCount(QModelIndex const& parent) const
 {
+    if (!m_model)
+        return 0;
     return m_model->row_count(to_gui(parent));
 }
 
@@ -47,6 +46,7 @@ static QVariant convert_variant(GUI::Variant const& value)
 
 QVariant ModelTranslator::data(QModelIndex const& index, int role) const
 {
+    VERIFY(m_model);
     switch (role) {
     case Qt::DisplayRole:
         return convert_variant(m_model->data(to_gui(index), GUI::ModelRole::Display));
@@ -59,11 +59,13 @@ QVariant ModelTranslator::data(QModelIndex const& index, int role) const
 
 QModelIndex ModelTranslator::index(int row, int column, QModelIndex const& parent) const
 {
+    VERIFY(m_model);
     return to_qt(m_model->index(row, column, to_gui(parent)));
 }
 
 QModelIndex ModelTranslator::parent(QModelIndex const& index) const
 {
+    VERIFY(m_model);
     return to_qt(m_model->parent_index(to_gui(index)));
 }
 
@@ -76,6 +78,7 @@ QModelIndex ModelTranslator::to_qt(GUI::ModelIndex const& index) const
 
 GUI::ModelIndex ModelTranslator::to_gui(QModelIndex const& index) const
 {
+    VERIFY(m_model);
     if (!index.isValid())
         return {};
     return m_model->unsafe_create_index(index.row(), index.column(), index.internalPointer());

--- a/ModelTranslator.h
+++ b/ModelTranslator.h
@@ -14,8 +14,14 @@ namespace Ladybird {
 class ModelTranslator final : public QAbstractItemModel {
     Q_OBJECT
 public:
-    explicit ModelTranslator(NonnullRefPtr<GUI::Model>);
     virtual ~ModelTranslator() override;
+
+    void set_underlying_model(RefPtr<GUI::Model> model)
+    {
+        beginResetModel();
+        m_model = model;
+        endResetModel();
+    }
 
     virtual int columnCount(QModelIndex const& parent) const override;
     virtual int rowCount(QModelIndex const& parent) const override;

--- a/SettingsDialog.cpp
+++ b/SettingsDialog.cpp
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Settings.h"
 #include "SettingsDialog.h"
+#include "Settings.h"
 #include <QCloseEvent>
 #include <QLabel>
 
@@ -27,7 +27,7 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
     QObject::connect(m_ok_button, &QPushButton::released, this, [this] {
         close();
     });
-    
+
     setWindowTitle("Settings");
     setFixedWidth(300);
     setLayout(m_layout);
@@ -35,7 +35,7 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
     setFocus();
 }
 
-void SettingsDialog::closeEvent(QCloseEvent *event)
+void SettingsDialog::closeEvent(QCloseEvent* event)
 {
     save();
     event->accept();

--- a/SettingsDialog.h
+++ b/SettingsDialog.h
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <QFormLayout>
 #include <QDialog>
-#include <QMainWindow>
+#include <QFormLayout>
 #include <QLineEdit>
+#include <QMainWindow>
 #include <QPushButton>
 
 #pragma once
@@ -16,7 +16,7 @@ class SettingsDialog : public QDialog {
     Q_OBJECT
 public:
     explicit SettingsDialog(QMainWindow* window);
-    
+
     void save();
 
     virtual void closeEvent(QCloseEvent*) override;

--- a/TimerQt.cpp
+++ b/TimerQt.cpp
@@ -91,5 +91,4 @@ void TimerQt::set_single_shot(bool single_shot)
     m_timer->setSingleShot(single_shot);
 }
 
-
 }

--- a/WebContentView.cpp
+++ b/WebContentView.cpp
@@ -77,7 +77,7 @@ WebContentView::WebContentView(StringView webdriver_content_ipc_path)
 
 WebContentView::~WebContentView()
 {
-    clear_inspector_callbacks();
+    close_sub_widgets();
 }
 
 void WebContentView::load(AK::URL const& url)
@@ -515,10 +515,14 @@ void WebContentView::ensure_inspector_widget()
     };
 }
 
-void WebContentView::clear_inspector_callbacks()
+void WebContentView::close_sub_widgets()
 {
-    if (m_inspector_widget)
-        m_inspector_widget->on_close = nullptr;
+    auto close_widget_window = [](auto* widget){
+        if (widget)
+            widget->close();
+    };
+    close_widget_window(m_console_widget);
+    close_widget_window(m_inspector_widget);
 }
 
 bool WebContentView::is_inspector_open() const

--- a/WebContentView.h
+++ b/WebContentView.h
@@ -192,7 +192,7 @@ private:
     bool is_inspector_open() const;
     void inspect_dom_tree();
     void clear_inspected_dom_node();
-    void clear_inspector_callbacks();
+    void close_sub_widgets();
     ErrorOr<Ladybird::DOMNodeProperties> inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> pseudo_element);
 
     qreal m_inverse_pixel_scaling_ratio { 1.0 };

--- a/WebContentView.h
+++ b/WebContentView.h
@@ -23,6 +23,8 @@
 #include <QAbstractScrollArea>
 #include <QPointer>
 
+#include "DOMNodeProperties.h"
+
 class QTextEdit;
 class QLineEdit;
 
@@ -189,9 +191,9 @@ private:
 
     bool is_inspector_open() const;
     void inspect_dom_tree();
-    void inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> pseudo_element);
     void clear_inspected_dom_node();
     void clear_inspector_callbacks();
+    ErrorOr<Ladybird::DOMNodeProperties> inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> pseudo_element);
 
     qreal m_inverse_pixel_scaling_ratio { 1.0 };
     bool m_should_show_line_box_borders { false };

--- a/WebContentView.h
+++ b/WebContentView.h
@@ -16,6 +16,7 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/StandardCursor.h>
+#include <LibWeb/CSS/Selector.h>
 #include <LibWebView/ViewImplementation.h>
 
 #include <LibWeb/Forward.h>
@@ -27,6 +28,7 @@ class QLineEdit;
 
 namespace Ladybird {
 class ConsoleWidget;
+class InspectorWidget;
 }
 
 namespace WebView {
@@ -185,13 +187,19 @@ private:
     void ensure_js_console_widget();
     void ensure_inspector_widget();
 
+    bool is_inspector_open() const;
+    void inspect_dom_tree();
+    void inspect_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement> pseudo_element);
+    void clear_inspected_dom_node();
+    void clear_inspector_callbacks();
+
     qreal m_inverse_pixel_scaling_ratio { 1.0 };
     bool m_should_show_line_box_borders { false };
 
-    QPointer<QWidget> m_inspector_widget;
     QPointer<QDialog> m_dialog;
 
     Ladybird::ConsoleWidget* m_console_widget { nullptr };
+    Ladybird::InspectorWidget* m_inspector_widget { nullptr };
 
     Gfx::IntRect m_viewport_rect;
 

--- a/WebSocketClientManagerLadybird.cpp
+++ b/WebSocketClientManagerLadybird.cpp
@@ -6,8 +6,8 @@
  */
 
 #include "WebSocketClientManagerLadybird.h"
-#include "WebSocketLadybird.h"
 #include "WebSocketImplQt.h"
+#include "WebSocketLadybird.h"
 
 namespace Ladybird {
 

--- a/WebSocketClientManagerLadybird.h
+++ b/WebSocketClientManagerLadybird.h
@@ -1,9 +1,9 @@
 /*
-* Copyright (c) 2022, Dex♪ <dexes.ttp@gmail.com>
-* Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
-*
-* SPDX-License-Identifier: BSD-2-Clause
-*/
+ * Copyright (c) 2022, Dex♪ <dexes.ttp@gmail.com>
+ * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 
 #include <LibWeb/WebSockets/WebSocket.h>
 #include <LibWebSocket/ConnectionInfo.h>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11597044/208324142-6726d25b-7ff1-4432-90d2-390d39b51f78.png)


This has been broken for a while now, and even when it did work it was very limited compared to Browser. 
This PR re-implements the inspector with _most_ features from good o' Browser now supported, the main things missing is the box-model and inspecting from the context menu.
  
